### PR TITLE
Implement delete-q! function to delete a single queue

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject factual/durable-queue "0.1.6"
+(defproject factual/durable-queue "0.1.7-SNAPSHOT"
   :description "a in-process task-queue that is backed by disk."
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/durable_queue.clj
+++ b/src/durable_queue.clj
@@ -625,15 +625,14 @@
                (delete-slab s)))
 
            (delete-q! [this q-name]
-             (locking this
-               (let [q-name (munge (name q-name))]
-                 (doseq [s (get @queue-name->slabs q-name)]
-                   (unmap s)
-                   (delete-slab s))
-                 (.clear (queue q-name))
-                 (swap! queue-name->stats assoc q-name nil)
-                 (swap! queue-name->slabs assoc q-name nil)
-                 (swap! queue-name->current-slab assoc q-name nil))))
+             (let [q-name (munge (name q-name))]
+               (doseq [s (get @queue-name->slabs q-name)]
+                 (unmap s)
+                 (delete-slab s))
+               (.clear (queue q-name))
+               (swap! queue-name->stats assoc q-name nil)
+               (swap! queue-name->slabs assoc q-name nil)
+               (swap! queue-name->current-slab assoc q-name nil)))
 
            (fsync [_]
              (doseq [slab (->> @queue-name->slabs vals (apply concat))]

--- a/src/durable_queue.clj
+++ b/src/durable_queue.clj
@@ -633,7 +633,6 @@
                  (.clear (queue q-name))
                  (swap! queue-name->stats assoc q-name nil)
                  (swap! queue-name->slabs assoc q-name nil)
-                 ;(let [reset-slab (create-new-slab q-name)]
                  (swap! queue-name->current-slab assoc q-name nil))))
 
            (fsync [_]


### PR DESCRIPTION
This function lets the client delete an individual named queue, besides just all of the data.

Useful for deleting corrupted queue files (such as that get created when the disk fills up). 